### PR TITLE
Various Windows fixes

### DIFF
--- a/src/tty.rs
+++ b/src/tty.rs
@@ -20,8 +20,10 @@ mod windows {
     use crate::tty::Stream;
     use crate::win32::{GetFileType, GetStdHandle};
     use crate::win32::{
-        HANDLE, INVALID_HANDLE_VALUE, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
+        INVALID_HANDLE_VALUE, STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE,
     };
+
+    use std::os::windows::raw::HANDLE;
 
     /// Returns true if the given stream is a tty.
     #[allow(clippy::let_and_return)]

--- a/src/win32.rs
+++ b/src/win32.rs
@@ -1,17 +1,13 @@
 #![allow(non_snake_case, dead_code)]
 
 use std::ffi::c_void;
+use std::os::windows::raw::HANDLE;
 
-pub type HANDLE = isize;
-pub type PCSTR = *const u8;
 pub type BOOL = i32;
 
 pub const FALSE: BOOL = 0i32;
 pub const TRUE: BOOL = 1i32;
-pub const OPEN_EXISTING: u32 = 3;
-pub const GENERIC_READ: u32 = 0x80000000;
-pub const GENERIC_WRITE: u32 = 0x40000000;
-pub const INVALID_HANDLE_VALUE: HANDLE = -1isize;
+pub const INVALID_HANDLE_VALUE: HANDLE = !0 as HANDLE;
 pub const ENABLE_ECHO_INPUT: u32 = 4;
 pub const STD_ERROR_HANDLE: u32 = 0xfffffff4;
 pub const STD_INPUT_HANDLE: u32 = 0xfffffff6;
@@ -20,16 +16,6 @@ pub const FILE_TYPE_CHAR: u32 = 2u32;
 
 #[link(name = "kernel32", kind = "raw-dylib")]
 extern "system" {
-    pub fn CloseHandle(hobject: HANDLE) -> BOOL;
-    pub fn CreateFileA(
-        lpfilename: PCSTR,
-        dwdesiredaccess: u32,
-        dwsharemode: u32,
-        lpsecurityattributes: *const c_void,
-        dwcreationdisposition: u32,
-        dwflagsandattributes: u32,
-        htemplatefile: HANDLE,
-    ) -> HANDLE;
     pub fn GetFileType(hfile: HANDLE) -> u32;
     pub fn GetConsoleMode(hconsolehandle: HANDLE, lpmode: *mut u32) -> BOOL;
     pub fn GetStdHandle(nstdhandle: u32) -> HANDLE;


### PR DESCRIPTION
* Return an error if `GetStdHandle()` returns a null handle, which can happen if running in a context where standard handles are not available.
* Avoid closing the handle in `prompt_password_stdin()`. Similar to `STDIN_FILENO` in the Unix implementation, the stdin handle is global and needs to stay open or else stdin can't be used anymore.
* Switch to using std's `HANDLE` type.
* Use `File` + `AsRawHandle` for `prompt_password_tty()` similar to the Unix implementation. This avoids needing to use `CreateFileA()` and `CloseFile()`.
* Use a `str` literal for `\r\n` instead of allocating a `String`.